### PR TITLE
docs: update logo to Ansys instead of PyAnsys

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -50,7 +50,7 @@ html_theme_options = {
         "version_match": get_version_match(version),
     },
     "check_switcher": False,
-    "logo": "pyansys",
+    "logo": "ansys",
 }
 
 # Sphinx extensions


### PR DESCRIPTION
Small PR to unify doc logos: all `scade-example*` and `scadeone-example*` repos should have an Ansys logo in their docs, not a PyAnsys one.